### PR TITLE
[noticket] Add Shopware 6.4 to require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
     "require": {
         "php": "^7.2",
         "unzerdev/php-sdk": "^1.1.1",
-        "shopware/core": "^6.2 || ^6.3.0",
-        "shopware/administration": "^6.2 || ^6.3.0",
-        "shopware/storefront": "^6.2 || ^6.3.0"
+        "shopware/core": "^6.2 || ^6.3 || ^6.4",
+        "shopware/administration": "^6.2 || ^6.3 || ^6.4",
+        "shopware/storefront": "^6.2 || ^6.3 || ^6.4"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12",


### PR DESCRIPTION
Add `^6.4` to all required shopware packages to enable installation without any hacks as according to the latest MR Shopware 6.4 should work with the unzerdev/shopware6 plugin version 2.0.1 or newer.