### PR TITLE
add: remove nestedLineItems from basket

### DIFF
--- a/src/Components/PaymentHandler/AbstractUnzerPaymentHandler.php
+++ b/src/Components/PaymentHandler/AbstractUnzerPaymentHandler.php
@@ -127,7 +127,15 @@ abstract class AbstractUnzerPaymentHandler implements AsynchronousPaymentHandler
 
             $this->pluginConfig = $this->configReader->read($salesChannelId);
             $this->unzerClient  = $this->clientFactory->createClient($salesChannelId, empty($currentRequest->getLocale()) ? $currentRequest->getDefaultLocale() : $currentRequest->getLocale());
-
+            if ($transaction->getOrder() && $transaction->getOrder()->getLineItems()) {
+                $array = array();
+                foreach ($transaction->getOrder()->getLineItems() as $element) {
+                    if (is_null($element->getParentId())) {
+                        array_push($array, $element);
+                    }
+                }
+                $transaction->getOrder()->setLineItems(new OrderLineItemCollection($array));
+            }
             $this->unzerBasket   = $this->basketHydrator->hydrateObject($salesChannelContext, $transaction);
             $this->unzerMetadata = $this->metadataHydrator->hydrateObject($salesChannelContext, $transaction);
             $this->unzerCustomer = $this->getUnzerCustomer($currentRequest->get('unzerCustomerId', ''), $transaction->getOrderTransaction()->getPaymentMethodId(), $salesChannelContext);


### PR DESCRIPTION
NestedtLineItems are included twice and the UnzerAPI is giving an error: `"exception":"[object] (UnzerSDK\\Exceptions\\UnzerApiException(code: API.600.410.062): Basket ''totalValueGross'' does not equals sum of (amountPerUnitGross - amountDiscountPerUnitGross) * quantity. at /var/www/html/custom/plugins/UnzerPayment6/vendor/unzerdev/php-sdk/src/Services/HttpService.php:195)"} []`

There needs to be a way to get rid of these "child-lineItems".
Not sure id the `parentId` ist the best and stable way, but works.