### PR TITLE
fix: 3rd party plugin compatibility

### DIFF
--- a/src/Resources/app/administration/src/module/unzer-payment-configuration/extension/sw-system-config/index.js
+++ b/src/Resources/app/administration/src/module/unzer-payment-configuration/extension/sw-system-config/index.js
@@ -12,12 +12,23 @@ Component.override('sw-system-config', {
             readOnlyUnzerGooglePayGatewayMerchantId: {}
         };
     },
-    methods: {
-        onSalesChannelChanged(salesChannelId) {
-            this.$super('onSalesChannelChanged', salesChannelId);
+    watch: {
+        currentSalesChannelId() {
+            this.getUnzerGooglePayGatewayMerchantId();
             this.$emit('sales-channel-changed', this.actualConfigData[this.currentSalesChannelId], this.currentSalesChannelId);
         },
-        readAll() {
+    },
+    computed: {
+        unzerGooglePayGatewayMerchantId() {
+            return this.readOnlyUnzerGooglePayGatewayMerchantId || '';
+        }
+    },
+    methods: {
+        async createdComponent() {
+            await this.$super('createdComponent');
+            this.getUnzerGooglePayGatewayMerchantId();
+        },
+        getUnzerGooglePayGatewayMerchantId() {
             if (this.domain === 'UnzerPayment6.settings') {
                 this.UnzerPaymentConfigurationService.getGooglePayGatewayMerchantId(this.currentSalesChannelId).then((response) => {
                     this.readOnlyUnzerGooglePayGatewayMerchantId = response.gatewayMerchantId;
@@ -26,10 +37,6 @@ Component.override('sw-system-config', {
 
                     });
             }
-            return this.$super('readAll');
-        },
-        getUnzerGooglePayGatewayMerchantId() {
-            return this.readOnlyUnzerGooglePayGatewayMerchantId || '';
         }
     }
 });

--- a/src/Resources/app/administration/src/module/unzer-payment-configuration/extension/sw-system-config/sw-system-config.html.twig
+++ b/src/Resources/app/administration/src/module/unzer-payment-configuration/extension/sw-system-config/sw-system-config.html.twig
@@ -13,7 +13,7 @@
         </template>
 
         <template v-if="element.name == 'UnzerPayment6.settings.googlePayMerchantName'">
-            <sw-text-field :value="getUnzerGooglePayGatewayMerchantId()"
+            <sw-text-field :value="unzerGooglePayGatewayMerchantId"
                            :label="$tc('unzer-payment-settings.google-pay.gatewayMerchantId')"
                            disabled>
             </sw-text-field>


### PR DESCRIPTION
Currently, the implementation of the system config extension breaks third-party plugins (e.g., b2bsellers). I changed the code to use a different approach to achieve the requested goal of the override.