### PR TITLE
v5.9.3

### DIFF
--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,8 @@
+# 5.9.3
+* Rechnungskauf: Charge ohne Rechnungsdokument möglich
+* "Paypal Account speichern" nun optional
+* Korrektur für Warenkorb-Items ohne Parent-ID oder Produkt-ID
+
 # 5.9.2
 * Rechnungskauf und Ratenkauf: Anpassung Zahlungsstatus für neue Bestellungen
 * Invoice Paylater: Entfernen der Payment-Informationen auf Success-Page, Daten wurden bereits per Mail an den Kunden geschickt

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -1,3 +1,8 @@
+# 5.9.3
+* Invoice (Paylater): Charge without Invoice document possible
+* "Save Paypal Account" now optional
+* Prevented lineItems with no Parent ID and Product ID to be hydrated
+
 # 5.9.2
 * Invoice and Installment : Adjust Payment Status for New Orders to be Authorized
 * Invoice Paylater: Delete the payment information in the order success page. Information is already sent by mail to end customer 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "unzerdev/shopware6",
     "description": "Unzer payment integration for Shopware 6",
-    "version": "5.9.2",
+    "version": "5.9.3",
     "type": "shopware-platform-plugin",
     "license": "Apache-2.0",
     "minimum-stability": "dev",

--- a/src/Components/ConfigReader/ConfigReader.php
+++ b/src/Components/ConfigReader/ConfigReader.php
@@ -40,6 +40,8 @@ class ConfigReader implements ConfigReaderInterface
     public const CONFIG_KEY_GOOGLE_PAY_BUTTON_COLOR = 'googlePayButtonColor';
     public const CONFIG_KEY_GOOGLE_PAY_BUTTON_SIZE_MODE = 'googlePayButtonSizeMode';
 
+    public const CONFIG_KEY_PAYPAL_SHOW_SAVE_ACCOUNT = 'paypalShowSaveAccount';
+
     private SystemConfigService $systemConfigService;
 
     public function __construct(SystemConfigService $systemConfigService)

--- a/src/Components/ResourceHydrator/BasketResourceHydrator.php
+++ b/src/Components/ResourceHydrator/BasketResourceHydrator.php
@@ -89,6 +89,10 @@ class BasketResourceHydrator implements ResourceHydratorInterface
 
         /** @var OrderLineItemEntity $lineItem */
         foreach ($lineItemCollection as $lineItem) {
+            if ($lineItem->getProductId() === null && $lineItem->getParentId() === null) {
+                continue;
+            }
+
             if ($this->isCustomProduct($lineItemCollection, $lineItem)) {
                 continue;
             }
@@ -222,6 +226,9 @@ class BasketResourceHydrator implements ResourceHydratorInterface
     protected function getAmount($lineItem, float $price): float
     {
         if ($price < 0 && $this->isPromotionLineItem($lineItem)) {
+            if ($lineItem->getQuantity() > 1) {
+                $price = $price / $lineItem->getQuantity();
+            }
             return $price * -1;
         }
 

--- a/src/Components/Struct/PageExtension/Checkout/Confirm/PayPalPageExtension.php
+++ b/src/Components/Struct/PageExtension/Checkout/Confirm/PayPalPageExtension.php
@@ -14,6 +14,20 @@ class PayPalPageExtension extends Struct
     /** @var UnzerPaymentDeviceEntity[] */
     protected $payPalAccounts = [];
 
+    protected array $publicConfig = [];
+
+    public function getPublicConfig(): array
+    {
+        return $this->publicConfig;
+    }
+
+    public function setPublicConfig(array $publicConfig): self
+    {
+        $this->publicConfig = $publicConfig;
+
+        return $this;
+    }
+
     public function addPayPalAccount(UnzerPaymentDeviceEntity $paypalAccount): self
     {
         $this->payPalAccounts[] = $paypalAccount;

--- a/src/Controllers/Administration/UnzerPaymentTransactionController.php
+++ b/src/Controllers/Administration/UnzerPaymentTransactionController.php
@@ -145,17 +145,9 @@ class UnzerPaymentTransactionController extends AbstractController
             if ($transaction->getPaymentMethodId() === PaymentInstaller::PAYMENT_ID_PAYLATER_INVOICE) {
                 $invoiceNumber = $this->getInvoiceNumber($transaction);
 
-                if ($invoiceNumber === null) {
-                    return new JsonResponse(
-                            [
-                            'status' => false,
-                            'errors' => ['paylater-invoice-document-required'],
-                        ],
-                        Response::HTTP_BAD_REQUEST
-                    );
+                if ($invoiceNumber !== null) {
+                    $charge->setInvoiceId($invoiceNumber);
                 }
-
-                $charge->setInvoiceId($invoiceNumber);
             }
 
             $client->performChargeOnPayment($orderTransactionId, $charge);

--- a/src/EventListeners/Checkout/ConfirmPageEventListener.php
+++ b/src/EventListeners/Checkout/ConfirmPageEventListener.php
@@ -263,6 +263,10 @@ class ConfirmPageEventListener implements EventSubscriberInterface
             $extension->addPayPalAccount($payPalAccount);
         }
 
+        $extension->setPublicConfig([
+            'paypalShowSaveAccount' => $this->configData->get(ConfigReader::CONFIG_KEY_PAYPAL_SHOW_SAVE_ACCOUNT),
+        ]);
+
         $event->getPage()->addExtension(PayPalPageExtension::EXTENSION_NAME, $extension);
     }
 

--- a/src/Resources/config/settings.xml
+++ b/src/Resources/config/settings.xml
@@ -137,6 +137,19 @@
         </component>
     </card>
 
+    <card>
+        <title>PayPal</title>
+        <title lang="de-DE">PayPal</title>
+
+        <input-field type="bool">
+            <name>paypalShowSaveAccount</name>
+            <label>Show 'Save PayPal Account for next order' on checkout</label>
+            <label lang="de-DE">Zeige 'PayPal Account für die nächste Bestellung speichern' auf Checkout-Seite</label>
+            <helpText>You need to have a 'PayPal Billing Agreement' with PayPal to make this work.</helpText>
+            <helpText lang="de-DE">Sie müssen ein 'PayPal Billing Agreement' mit PayPal haben, um dieses Feature nutzen zu können.</helpText>
+        </input-field>
+    </card>
+
 
     <card>
         <title>Google Pay</title>

--- a/src/Resources/views/storefront/component/unzer/frames/paypal.html.twig
+++ b/src/Resources/views/storefront/component/unzer/frames/paypal.html.twig
@@ -1,6 +1,6 @@
 {% block unzer_payment_frame_paypal_account %}
     {% set hasSavedAccounts = page.extensions.unzerPayPal.payPalAccounts|length > 0 %}
-    {% set showAccountSave = not context.customer.guest %}
+    {% set showAccountSave = not context.customer.guest and page.extensions.unzerPayPal.publicConfig.paypalShowSaveAccount %}
     {% set showTitle = hasSavedAccounts or showAccountSave %}
 
     {% block unzer_payment_checkout_confirm_frame_card_body_title %}


### PR DESCRIPTION
* Invoice (Paylater): Charge without Invoice document possible
* "Save Paypal Account" now optional
* Prevented lineItems with no Parent ID and Product ID to be hydrated