### PR TITLE
Fix payment form breaking after error message

### DIFF
--- a/src/Resources/app/storefront/src/unzer/unzer-payment.base.plugin.js
+++ b/src/Resources/app/storefront/src/unzer/unzer-payment.base.plugin.js
@@ -113,6 +113,7 @@ export default class UnzerPaymentBasePlugin extends Plugin {
         errorWrapper.hidden = false;
         errorWrapper.scrollIntoView({ block: 'end', behavior: 'smooth' });
 
+        this.submitting = false;
         this.setSubmitButtonActive(true);
     }
 


### PR DESCRIPTION
When you submit for example invoice paylater without agreeing to the data processing, you get an error via showError() in the payment methods `_onCreateResource()`.

However `showError()` never sets `submitting` back to `false`, so any clicks on the submit button after an error never get any processing and `unzerResourceId` never gets assigned any value, completely bricking the transaction.

-- 

As an aside, I don't believe setting the submit button blindly to be active in `showError()` makes much sense either as quite a few payment methods disable that button by default. However fixing and investigating that for every single payment method was out of scope for this PR.