### PR TITLE
fix: Always update the plugin id when updating the payments

### DIFF
--- a/src/Installer/PaymentInstaller.php
+++ b/src/Installer/PaymentInstaller.php
@@ -571,6 +571,7 @@ class PaymentInstaller implements InstallerInterface
                 // method does exist > only update necessary fields
                 $upsertPayload = [
                     'id' => $paymentMethod['id'],
+                    'pluginId' => $pluginId,
                     'technicalName' => $paymentMethod['technicalName'],
                 ];
                 $this->paymentMethodRepository->upsert([$upsertPayload], $context->getContext());


### PR DESCRIPTION
We ran into the issue, that the plugin was uninstalled (due to an issue in the CI pipeline), which lead to the `plugin_id`s to be null.

This PR now makes sure to have the correct plugin id in the `payment_method` table.