### PR TITLE
v7.1.4

### DIFF
--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,8 @@
+# 7.1.4
+* **Wichtiger Hotfix**
+* Dieser Hotfix behebt ein Problem, bei dem einige Webhooks in Shopware 6.7 nicht korrekt registriert wurden.
+* Installieren Sie diesen Hotfix, um ein Problem zu beheben, das in der vorherigen Version v7.1.3 gefunden wurde.
+
 # 7.1.3
 * Fehler behoben, bei dem die AGB nicht bis zum Akzeptieren-Häkchen gescrollt wurden
 * Falsche UI-Komponente für B2B-Rechnung korrigiert
@@ -16,8 +21,8 @@
 # 7.1.0
 * Migration von Unzer UI Component V1 zu Unzer UI Component V2
 * Express-Checkout für Apple Pay, Google Pay und PayPal wurde hinzugefügt
-* EAA-Unterstützung, siehe https://docs.unzer.com/online-payments/compliance/eaa/￼
-* Veraltete Zahlungsmethoden wurden durch neue ersetzt, entfernt oder umbenannt. Die vollständige Liste befindet sich unter https://docs.unzer.com/plugins/shopware-6/shop6-migrate-v1-v2/￼
+* EAA-Unterstützung, siehe https://docs.unzer.com/online-payments/compliance/eaa/
+* Veraltete Zahlungsmethoden wurden durch neue ersetzt, entfernt oder umbenannt. Die vollständige Liste befindet sich unter https://docs.unzer.com/plugins/shopware-6/shop6-migrate-v1-v2/
 
 # 7.0.0
 * Support for Shopware 6.7

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -1,3 +1,8 @@
+# 7.1.4
+* **Important hotfix**
+* This hotfix will fix an issue where some webhooks were not correctly registered in Shopware 6.7.
+* Install this hotfix to solve an issue found in previous release v7.1.3
+
 # 7.1.3
 * Fix for Terms and Conditions no scroll to accept checkmark
 * Fix incorrect UI Comp. for B2B invoice

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "unzerdev/shopware6",
     "description": "Unzer payment integration for Shopware 6",
-    "version": "7.1.3",
+    "version": "7.1.4",
     "type": "shopware-platform-plugin",
     "license": "Apache-2.0",
     "minimum-stability": "dev",

--- a/src/Components/WebhookHandler/PaymentStatusWebhookHandler.php
+++ b/src/Components/WebhookHandler/PaymentStatusWebhookHandler.php
@@ -54,8 +54,6 @@ class PaymentStatusWebhookHandler implements WebhookHandlerInterface
 
         $transaction = $this->getOrderTransaction($payment->getOrderId(), $context->getContext());
 
-        $context->getContext()->assign(['languageIdChain' => [$transaction->getOrder()->getLanguageId()]]);
-
         if ($transaction === null) {
             $this->logger->error(
                 \sprintf(
@@ -67,6 +65,7 @@ class PaymentStatusWebhookHandler implements WebhookHandlerInterface
             return;
         }
 
+        $context->getContext()->assign(['languageIdChain' => [$transaction->getOrder()->getLanguageId()]]);
         $this->customFieldsHelper->setOrderTransactionCustomFields($transaction, $context->getContext());
 
         $this->transactionStateHandler->transformTransactionState(
@@ -83,6 +82,7 @@ class PaymentStatusWebhookHandler implements WebhookHandlerInterface
         }
 
         $criteria = new Criteria([$orderId]);
+        $criteria->addAssociation('order');
 
         try {
             $orderTransactions = $this->orderTransactionRepository->search($criteria, $context);
@@ -95,3 +95,4 @@ class PaymentStatusWebhookHandler implements WebhookHandlerInterface
         }
     }
 }
+


### PR DESCRIPTION
# Important hotfix

This hotfix will fix an issue where some webhooks were not correctly registered in Shopware 6.7.
Install this hotfix to solve an issue found in previous release v7.1.3