### PR TITLE
v6.5.3

### DIFF
--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,8 @@
+# 6.5.3
+* **Wichtiger Hotfix**
+* Dieser Hotfix behebt ein Problem, bei dem einige Webhooks in Shopware 6.6 nicht korrekt registriert wurden.
+* Installieren Sie diesen Hotfix, um ein Problem zu beheben, das in der vorherigen Version v6.5.2 gefunden wurde.
+
 # 6.5.2
 * Fehler behoben, bei dem die AGB nicht bis zum Akzeptieren-Häkchen gescrollt wurden
 * Falsche UI-Komponente für B2B-Rechnung korrigiert

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -1,3 +1,8 @@
+# 6.5.3
+* **Important hotfix**
+* This hotfix will fix an issue where some webhooks were not correctly registered in Shopware 6.6.
+* Install this hotfix to solve an issue found in previous release v6.5.2
+
 # 6.5.2
 * Fix for Terms and Conditions no scroll to accept checkmark
 * Fix incorrect UI Comp. for B2B invoice

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "unzerdev/shopware6",
     "description": "Unzer payment integration for Shopware 6",
-    "version": "6.5.2",
+    "version": "6.5.3",
     "type": "shopware-platform-plugin",
     "license": "Apache-2.0",
     "minimum-stability": "dev",

--- a/src/Components/WebhookHandler/PaymentStatusWebhookHandler.php
+++ b/src/Components/WebhookHandler/PaymentStatusWebhookHandler.php
@@ -54,8 +54,6 @@ class PaymentStatusWebhookHandler implements WebhookHandlerInterface
 
         $transaction = $this->getOrderTransaction($payment->getOrderId(), $context->getContext());
 
-        $context->getContext()->assign(['languageIdChain' => [$transaction->getOrder()->getLanguageId()]]);
-
         if ($transaction === null) {
             $this->logger->error(
                 \sprintf(
@@ -67,6 +65,7 @@ class PaymentStatusWebhookHandler implements WebhookHandlerInterface
             return;
         }
 
+        $context->getContext()->assign(['languageIdChain' => [$transaction->getOrder()->getLanguageId()]]);
         $this->customFieldsHelper->setOrderTransactionCustomFields($transaction, $context->getContext());
 
         $this->transactionStateHandler->transformTransactionState(
@@ -83,6 +82,7 @@ class PaymentStatusWebhookHandler implements WebhookHandlerInterface
         }
 
         $criteria = new Criteria([$orderId]);
+        $criteria->addAssociation('order');
 
         try {
             $orderTransactions = $this->orderTransactionRepository->search($criteria, $context);


### PR DESCRIPTION
# Important hotfix
This hotfix will fix an issue where some webhooks were not correctly registered in Shopware 6.6.
Install this hotfix to solve an issue found in previous release v6.5.2